### PR TITLE
fix(test): repair feed assertion broken by mid-pipeline comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
       <h2>Projects</h2>
       <ul>
         <li><a href="https://bus.hexa.pro">Bus information system for UNIST</a>, Host by Hacking and Programming Club <a href="https://hexa.pro">HeXA</a></li>
-        <!--- li>Speaki: Automatic grading system for Introduction to AI Programming Course (101 for AI)</li !--->
+        <!-- <li>Speaki: Automatic grading system for Introduction to AI Programming Course (101 for AI)</li> -->
       </ul>
     </section>
 

--- a/script/site-checks.sh
+++ b/script/site-checks.sh
@@ -45,9 +45,11 @@ if [ ! -f "$feed" ]; then
 else
   # Only structural <link href="..."> elements: relative URLs inside CDATA
   # post content are valid per Atom spec (resolved against xml:base)
+  # Flag any href that does NOT start with https:// (includes http://, //host,
+  # /absolute-path, and scheme-less hostnames)
   bad=$(grep -o '<link[^>]*href="[^"]*"' "$feed" \
         | sed 's/.*href="//;s/"$//' \
-        | grep -E '(^raon1123\.github\.io|^/[^/])' \
+        | grep -vE '^https://' \
         || true)
   if [ -n "$bad" ]; then
     fail "feed.xml: found href values that are not absolute https:// URLs:"


### PR DESCRIPTION
A comment inserted between pipeline stages in a command substitution is a runtime syntax error bash -n does not catch; the feed check silently skipped instead of failing. Keep the stricter intent (reject any <link> href not starting with https://) and move the comment above the pipeline.

Also normalize the commented-out Speaki entry in index.html to standard HTML comment syntax.