### PR TITLE
chore: jQuery 3.3.1 → 3.7.1 업그레이드

### DIFF
--- a/_data/variables.yml
+++ b/_data/variables.yml
@@ -42,7 +42,7 @@ default:
 sources:
   bootcdn:
     font_awesome: 'https://cdn.bootcdn.net/ajax/libs/font-awesome/5.15.1/css/all.css'
-    jquery: 'https://cdn.bootcss.com/jquery/3.1.1/jquery.min.js'
+    jquery: 'https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js' # bootcss domain stale
     leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://cdn.bootcss.com/Chart.js/2.7.2/Chart.bundle.min.js'
     gitalk:
@@ -53,7 +53,7 @@ sources:
     mermaid: 'https://cdn.bootcss.com/mermaid/8.0.0-rc.8/mermaid.min.js'
   unpkg:
     font_awesome: 'https://use.fontawesome.com/releases/v5.15.1/css/all.css'
-    jquery: 'https://unpkg.com/jquery@3.3.1/dist/jquery.min.js'
+    jquery: 'https://unpkg.com/jquery@3.7.1/dist/jquery.min.js'
     leancloud_js_sdk: '//cdn.jsdelivr.net/npm/leancloud-storage@3.13.2/dist/av-min.js'
     chart: 'https://unpkg.com/chart.js@2.7.2/dist/Chart.min.js'
     gitalk:


### PR DESCRIPTION
## 변경 사항
`_data/variables.yml` 2개 라인:
- **unpkg** (활성 소스, `_config.yml sources: unpkg`): `jquery@3.3.1` → `jquery@3.7.1`
- **bootcdn** 소스: 노후 `cdn.bootcss.com` 3.1.1 → jsdelivr 3.7.1 (해당 블록은 이미 jsdelivr/unpkg 혼용)

## 위험-이득
- 해소: CVE-2019-11358(prototype pollution), CVE-2020-11022/11023(htmlPrefilter XSS)
- 유일한 동작 차이: jQuery 3.5 htmlPrefilter 변경(self-closing 태그) — 테마 영향 없음 확인

## 검증
- [x] 새 CDN URL 사전 200 확인 (unpkg, jsdelivr)
- [x] diff가 variables.yml 2라인으로 한정
- [x] `jekyll build` exit 0, `_site`에서 구버전(3.3.1/3.1.1) 잔존 0건, 3.7.1 참조 27페이지
- [x] 로컬 serve 스모크: `/blog/`, `/blog/page2/`, 수식 글, Roadmap-AI 모두 200 + 3.7.1 script 태그 (메인 랜딩은 원래 jQuery 미사용 — 라이브와 동일)
- [ ] 머지 후 브라우저 수동 스모크 권장: TOC 하이라이트, 사이드바 토글, 검색 모달, scroll-to-top

🤖 Generated with [Claude Code](https://claude.com/claude-code)